### PR TITLE
Add sportsipy data fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Run the following to run Flow Dev, the Emulator, and Dev Wallet:
 npm run dev:local
 ```
 
+### Sports Data Backend
+
+A FastAPI service provides multi-league game and player data. It attempts to pull real stats using the `sportsipy` library and falls back to bundled sample data if live stats aren't available. It also handles basic prediction tracking. Start it with:
+
+```
+npm run dev:sports-backend
+```
+
 Note: Flow Dev will will automatically create new accounts and deploy for you while developing. Your flow.json will be updated automatically. Committing these changes for local development is unncessary.
 
 ### Testnet

--- a/backend/data/sample_data.json
+++ b/backend/data/sample_data.json
@@ -1,0 +1,58 @@
+{
+  "nba": {
+    "games": [
+      {
+        "gameId": "NBA1",
+        "homeTeam": {"teamId": "LAL", "name": "Lakers", "score": 102},
+        "awayTeam": {"teamId": "BOS", "name": "Celtics", "score": 99},
+        "startTime": "2024-01-01T00:00:00Z",
+        "status": "FINAL"
+      }
+    ],
+    "players": {
+      "LAL23": {"playerId": "LAL23", "name": "LeBron James", "teamId": "LAL", "points": 25, "rebounds": 7, "assists": 8}
+    }
+  },
+  "nfl": {
+    "games": [
+      {
+        "gameId": "NFL1",
+        "homeTeam": {"teamId": "KC", "name": "Chiefs", "score": 31},
+        "awayTeam": {"teamId": "SF", "name": "49ers", "score": 24},
+        "startTime": "2024-01-01T00:00:00Z",
+        "status": "FINAL"
+      }
+    ],
+    "players": {
+      "KC15": {"playerId": "KC15", "name": "Patrick Mahomes", "teamId": "KC", "passingYards": 350, "touchdowns": 3}
+    }
+  },
+  "nhl": {
+    "games": [
+      {
+        "gameId": "NHL1",
+        "homeTeam": {"teamId": "BOS", "name": "Bruins", "score": 4},
+        "awayTeam": {"teamId": "NYR", "name": "Rangers", "score": 2},
+        "startTime": "2024-01-01T00:00:00Z",
+        "status": "FINAL"
+      }
+    ],
+    "players": {
+      "BOS37": {"playerId": "BOS37", "name": "Patrice Bergeron", "teamId": "BOS", "goals": 2, "assists": 1}
+    }
+  },
+  "mlb": {
+    "games": [
+      {
+        "gameId": "MLB1",
+        "homeTeam": {"teamId": "NYY", "name": "Yankees", "score": 5},
+        "awayTeam": {"teamId": "BOS", "name": "Red Sox", "score": 3},
+        "startTime": "2024-01-01T00:00:00Z",
+        "status": "FINAL"
+      }
+    ],
+    "players": {
+      "NYY99": {"playerId": "NYY99", "name": "Aaron Judge", "teamId": "NYY", "hits": 2, "homeRuns": 1, "RBIs": 3}
+    }
+  }
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,4 +2,5 @@ fastapi==0.68.1
 uvicorn==0.15.0
 nba_api==1.1.9
 python-dotenv==0.19.0
-requests==2.26.0 
+requests==2.26.0
+sportsipy==0.6.0

--- a/backend/sports_service.py
+++ b/backend/sports_service.py
@@ -1,0 +1,174 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import json
+import os
+from datetime import datetime
+import logging
+
+try:
+    from sportsipy.nba.boxscore import Boxscores as NBABoxscores
+    from sportsipy.nba.roster import Player as NBAPlayer
+    from sportsipy.nfl.boxscore import Boxscores as NFLBoxscores
+    from sportsipy.nfl.roster import Player as NFLPlayer
+    from sportsipy.mlb.boxscore import Boxscores as MLBBoxscores
+    from sportsipy.mlb.roster import Player as MLBPlayer
+    from sportsipy.nhl.boxscore import Boxscores as NHLBoxscores
+    from sportsipy.nhl.roster import Player as NHLPlayer
+    SPORTS_LIB_AVAILABLE = True
+except Exception as e:
+    logging.exception("sportsipy not available: %s", e)
+    SPORTS_LIB_AVAILABLE = False
+
+app = FastAPI(
+    title="Sports Stats API",
+    description="Multi-league sports data and prediction service",
+    version="1.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), "data", "sample_data.json")
+with open(DATA_FILE) as f:
+    DATA = json.load(f)
+
+predictions = []
+prediction_counter = 1
+
+class PredictionIn(BaseModel):
+    league: str
+    gameId: str
+    predictedWinner: str
+
+@app.get("/")
+async def root():
+    return {"message": "Sports Stats API", "leagues": list(DATA.keys())}
+
+@app.get("/api/{league}/games")
+async def get_games(league: str):
+    league = league.lower()
+
+    games = None
+    if SPORTS_LIB_AVAILABLE:
+        games = _fetch_games_from_library(league)
+
+    if not games:
+        if league not in DATA:
+            raise HTTPException(status_code=404, detail="League not found")
+        return DATA[league]["games"]
+
+    return games
+
+@app.get("/api/{league}/players/{player_id}")
+async def get_player_stats(league: str, player_id: str):
+    league = league.lower()
+
+    player = None
+    if SPORTS_LIB_AVAILABLE:
+        player = _fetch_player_from_library(league, player_id)
+
+    if not player:
+        if league not in DATA:
+            raise HTTPException(status_code=404, detail="League not found")
+        players = DATA[league]["players"]
+        if player_id not in players:
+            raise HTTPException(status_code=404, detail="Player not found")
+        return players[player_id]
+
+    return player
+
+@app.post("/api/predictions")
+async def submit_prediction(pred: PredictionIn):
+    global prediction_counter
+    entry = pred.dict()
+    entry["id"] = prediction_counter
+    entry["correct"] = evaluate_prediction(entry)
+    prediction_counter += 1
+    predictions.append(entry)
+    return entry
+
+@app.get("/api/predictions")
+async def list_predictions():
+    for p in predictions:
+        if p["correct"] is None:
+            p["correct"] = evaluate_prediction(p)
+    return predictions
+
+def evaluate_prediction(pred):
+    league = pred["league"].lower()
+    if league not in DATA:
+        return None
+    game = next((g for g in DATA[league]["games"] if g["gameId"] == pred["gameId"]), None)
+    if not game or game.get("status") != "FINAL":
+        return None
+    winner = game["homeTeam"]["teamId"] if game["homeTeam"].get("score", 0) >= game["awayTeam"].get("score", 0) else game["awayTeam"]["teamId"]
+    return pred["predictedWinner"].lower() == winner.lower()
+
+
+def _fetch_games_from_library(league: str):
+    """Attempt to fetch games from sportsipy for the given league."""
+    today = datetime.utcnow().date()
+    key = f"{today.month}-{today.day}-{today.year}"
+    try:
+        if league == "nba":
+            bs = NBABoxscores(today)
+        elif league == "nfl":
+            bs = NFLBoxscores(today)
+        elif league == "mlb":
+            bs = MLBBoxscores(today)
+        elif league == "nhl":
+            bs = NHLBoxscores(today)
+        else:
+            return None
+        raw_games = bs.games.get(key, [])
+        games = []
+        for g in raw_games:
+            games.append({
+                "gameId": g.get("boxscore"),
+                "homeTeam": {
+                    "teamId": g.get("home_name"),
+                    "name": g.get("home_name"),
+                    "score": g.get("home_score"),
+                },
+                "awayTeam": {
+                    "teamId": g.get("away_name"),
+                    "name": g.get("away_name"),
+                    "score": g.get("away_score"),
+                },
+                "startTime": g.get("time", ""),
+                "status": "FINAL" if g.get("home_score") is not None else "SCHEDULED",
+            })
+        return games
+    except Exception as exc:
+        logging.exception("Failed fetching %s games: %s", league, exc)
+        return None
+
+
+def _fetch_player_from_library(league: str, player_id: str):
+    """Attempt to fetch player stats using sportsipy."""
+    try:
+        if league == "nba":
+            p = NBAPlayer(player_id)
+        elif league == "nfl":
+            p = NFLPlayer(player_id)
+        elif league == "mlb":
+            p = MLBPlayer(player_id)
+        elif league == "nhl":
+            p = NHLPlayer(player_id)
+        else:
+            return None
+        data = {k.lstrip("_"): v for k, v in vars(p).items() if not k.startswith("_")}
+        return data
+    except Exception as exc:
+        logging.exception("Failed fetching %s player %s: %s", league, player_id, exc)
+        return None
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "flow:emulator": "flow emulator",
     "flow:dev-wallet": "flow dev-wallet",
     "dev:backend": "cd backend && source ~/.venv/bin/activate && python3 -m uvicorn nba_service:app --reload",
+    "dev:sports-backend": "cd backend && source ~/.venv/bin/activate && python3 -m uvicorn sports_service:app --reload",
     "dev:all": "concurrently --kill-others-on-fail \"yarn flow:emulator\" \"yarn flow:dev-wallet\" \"yarn dev:local:flow\" \"yarn dev:backend\"",
     "build:css": "tailwindcss build styles/globals.css -o styles/output.css"
   },

--- a/pages/__tests__/games.test.tsx
+++ b/pages/__tests__/games.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import GamesPage from '../games'
+import { SportsService } from '../../services/sports'
+
+jest.mock('../../services/sports')
+
+const mockGames = [
+  { gameId: '1', homeTeam: { teamId: 'H', name: 'Home' }, awayTeam: { teamId: 'A', name: 'Away' }, status: 'SCHEDULED' }
+]
+
+;(SportsService.getGames as jest.Mock).mockResolvedValue(mockGames)
+
+describe('GamesPage', () => {
+  it('fetches and displays games', async () => {
+    render(<GamesPage />)
+    expect(SportsService.getGames).toHaveBeenCalledWith('nba')
+    await waitFor(() => expect(screen.getByText(/Home/)).toBeInTheDocument())
+    expect(screen.getByText(/Away/)).toBeInTheDocument()
+  })
+})

--- a/pages/__tests__/player.test.tsx
+++ b/pages/__tests__/player.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import PlayerStatsPage from '../player'
+import { SportsService } from '../../services/sports'
+
+jest.mock('../../services/sports')
+
+const mockPlayer = { playerId: 'P1', name: 'Test Player' }
+;(SportsService.getPlayerStats as jest.Mock).mockResolvedValue(mockPlayer)
+
+describe('PlayerStatsPage', () => {
+  it('fetches player stats', async () => {
+    render(<PlayerStatsPage />)
+    fireEvent.change(screen.getByPlaceholderText(/player id/i), { target: { value: 'P1' } })
+    fireEvent.click(screen.getByText(/Load Stats/i))
+    await waitFor(() => expect(SportsService.getPlayerStats).toHaveBeenCalled())
+    expect(screen.getByText(/Test Player/)).toBeInTheDocument()
+  })
+})

--- a/pages/games.tsx
+++ b/pages/games.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+import { SportsService } from '../services/sports'
+
+interface Game {
+  gameId: string
+  homeTeam: { teamId: string; name: string; score?: number }
+  awayTeam: { teamId: string; name: string; score?: number }
+  startTime?: string
+  status: string
+}
+
+const leagues = ['nba', 'nfl', 'nhl', 'mlb']
+
+export default function GamesPage() {
+  const [league, setLeague] = useState('nba')
+  const [games, setGames] = useState<Game[]>([])
+
+  useEffect(() => {
+    SportsService.getGames(league).then(setGames)
+  }, [league])
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Upcoming Games</h1>
+      <select value={league} onChange={e => setLeague(e.target.value)} className="border p-2 rounded">
+        {leagues.map(l => (
+          <option key={l} value={l}>{l.toUpperCase()}</option>
+        ))}
+      </select>
+      <ul className="space-y-2">
+        {games.map(g => (
+          <li key={g.gameId} className="border p-2 rounded">
+            <span className="font-medium">{g.awayTeam.name}</span> at <span className="font-medium">{g.homeTeam.name}</span>
+            <span className="ml-2 text-sm text-gray-500">{g.status}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,6 +30,9 @@ export default function Home() {
             <h1 className="text-2xl font-bold bg-gradient-to-r from-blue-600 to-blue-400 bg-clip-text text-transparent">
               Legendary Picks
             </h1>
+            <a href="/predict" className="text-sm text-blue-600 hover:underline">
+              Predictions
+            </a>
             <div className="flex items-center gap-4">
               {user.loggedIn && (
                 <span className="text-sm text-gray-500">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,9 +30,11 @@ export default function Home() {
             <h1 className="text-2xl font-bold bg-gradient-to-r from-blue-600 to-blue-400 bg-clip-text text-transparent">
               Legendary Picks
             </h1>
-            <a href="/predict" className="text-sm text-blue-600 hover:underline">
-              Predictions
-            </a>
+            <nav className="space-x-4 text-sm">
+              <a href="/games" className="text-blue-600 hover:underline">Games</a>
+              <a href="/player" className="text-blue-600 hover:underline">Player Stats</a>
+              <a href="/predict" className="text-blue-600 hover:underline">Predictions</a>
+            </nav>
             <div className="flex items-center gap-4">
               {user.loggedIn && (
                 <span className="text-sm text-gray-500">

--- a/pages/player.tsx
+++ b/pages/player.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { SportsService } from '../services/sports'
+
+const leagues = ['nba', 'nfl', 'nhl', 'mlb']
+
+export default function PlayerStatsPage() {
+  const [league, setLeague] = useState('nba')
+  const [playerId, setPlayerId] = useState('')
+  const [stats, setStats] = useState<any | null>(null)
+
+  const fetchStats = async () => {
+    if (!playerId) return
+    const data = await SportsService.getPlayerStats(league, playerId)
+    setStats(data)
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Player Stats</h1>
+      <div className="flex gap-2">
+        <select value={league} onChange={e => setLeague(e.target.value)} className="border p-2 rounded">
+          {leagues.map(l => (
+            <option key={l} value={l}>{l.toUpperCase()}</option>
+          ))}
+        </select>
+        <input value={playerId} onChange={e => setPlayerId(e.target.value)} placeholder="Player ID" className="border p-2 rounded" />
+        <button onClick={fetchStats} className="bg-blue-600 text-white px-4 py-2 rounded">Load Stats</button>
+      </div>
+      {stats && (
+        <pre className="bg-gray-100 p-4 rounded overflow-auto text-sm">{JSON.stringify(stats, null, 2)}</pre>
+      )}
+    </div>
+  )
+}

--- a/pages/predict.tsx
+++ b/pages/predict.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react'
+import { SportsService } from '../services/sports'
+
+interface Game {
+  gameId: string
+  homeTeam: { teamId: string; name: string; score?: number }
+  awayTeam: { teamId: string; name: string; score?: number }
+  status: string
+}
+
+interface Prediction {
+  id: number
+  league: string
+  gameId: string
+  predictedWinner: string
+  correct: boolean | null
+}
+
+const leagues = ['nba', 'nfl', 'nhl', 'mlb']
+
+export default function PredictionsPage() {
+  const [league, setLeague] = useState('nba')
+  const [games, setGames] = useState<Game[]>([])
+  const [selectedGame, setSelectedGame] = useState('')
+  const [predictedWinner, setPredictedWinner] = useState('')
+  const [predictions, setPredictions] = useState<Prediction[]>([])
+
+  useEffect(() => {
+    const fetchGames = async () => {
+      const g = await SportsService.getGames(league)
+      setGames(g)
+      if (g.length > 0) {
+        setSelectedGame(g[0].gameId)
+        setPredictedWinner(g[0].homeTeam.teamId)
+      }
+    }
+    fetchGames()
+  }, [league])
+
+  useEffect(() => {
+    const fetchPreds = async () => {
+      const p = await SportsService.getPredictions()
+      setPredictions(p)
+    }
+    fetchPreds()
+  }, [])
+
+  const submit = async () => {
+    await SportsService.submitPrediction(league, selectedGame, predictedWinner)
+    const p = await SportsService.getPredictions()
+    setPredictions(p)
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Predictions</h1>
+      <div className="space-y-4">
+        <div className="flex gap-2">
+          <select value={league} onChange={e => setLeague(e.target.value)} className="border p-2 rounded">
+            {leagues.map(l => <option key={l} value={l}>{l.toUpperCase()}</option>)}
+          </select>
+          <select value={selectedGame} onChange={e => setSelectedGame(e.target.value)} className="border p-2 rounded">
+            {games.map(g => (
+              <option key={g.gameId} value={g.gameId}>
+                {g.awayTeam.name} at {g.homeTeam.name}
+              </option>
+            ))}
+          </select>
+          <select value={predictedWinner} onChange={e => setPredictedWinner(e.target.value)} className="border p-2 rounded">
+            {selectedGame && (
+              games.filter(g => g.gameId === selectedGame).map(g => (
+                [g.homeTeam, g.awayTeam].map(t => (
+                  <option key={t.teamId} value={t.teamId}>{t.name}</option>
+                ))
+              ))
+            )}
+          </select>
+          <button onClick={submit} className="bg-blue-600 text-white px-4 py-2 rounded">Submit</button>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <h2 className="text-xl font-semibold mb-2">Your Predictions</h2>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left">League</th>
+              <th className="text-left">Game</th>
+              <th className="text-left">Prediction</th>
+              <th className="text-left">Correct?</th>
+            </tr>
+          </thead>
+          <tbody>
+            {predictions.map(p => (
+              <tr key={p.id} className="border-t">
+                <td className="pr-2 py-1">{p.league.toUpperCase()}</td>
+                <td className="pr-2 py-1">{p.gameId}</td>
+                <td className="pr-2 py-1">{p.predictedWinner}</td>
+                <td className="pr-2 py-1">{p.correct === null ? 'Pending' : p.correct ? 'Yes' : 'No'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/services/sports.ts
+++ b/services/sports.ts
@@ -1,0 +1,45 @@
+import axios from 'axios'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_SPORTS_API_URL || 'http://localhost:8000/api'
+
+export const SportsService = {
+  getGames: async (league: string) => {
+    try {
+      const res = await axios.get(`${API_BASE_URL}/${league}/games`)
+      return res.data
+    } catch (err) {
+      console.error('Error fetching games', err)
+      return []
+    }
+  },
+
+  getPlayerStats: async (league: string, playerId: string) => {
+    try {
+      const res = await axios.get(`${API_BASE_URL}/${league}/players/${playerId}`)
+      return res.data
+    } catch (err) {
+      console.error('Error fetching player', err)
+      return null
+    }
+  },
+
+  submitPrediction: async (league: string, gameId: string, predictedWinner: string) => {
+    try {
+      const res = await axios.post(`${API_BASE_URL}/predictions`, { league, gameId, predictedWinner })
+      return res.data
+    } catch (err) {
+      console.error('Error submitting prediction', err)
+      return null
+    }
+  },
+
+  getPredictions: async () => {
+    try {
+      const res = await axios.get(`${API_BASE_URL}/predictions`)
+      return res.data
+    } catch (err) {
+      console.error('Error getting predictions', err)
+      return []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- fetch live game and player data using sportsipy with a fallback to sample JSON
- document sportsipy usage in README
- require sportsipy in backend requirements

## Testing
- `npm run build:css` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437041e6bc832eaa92744aec124f83